### PR TITLE
Fix video ordering

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -202,9 +202,5 @@ if HEROKU:
     SESSION_COOKIE_SAMESITE = "None"
     SESSION_COOKIE_DOMAIN = SITENAME
 
-    DISABLE_SERVER_SIDE_CURSORS = (
-        True  # required when using pgbouncer's pool_mode=transaction
-    )
-
     django_on_heroku.settings(locals())
     config = locals()

--- a/notifier/lib/database_iterator.py
+++ b/notifier/lib/database_iterator.py
@@ -95,7 +95,7 @@ def collect_new_videos():
 def _save_data(collected_videos, search_query):
     videos = []
     LOGGER.info("Collector - %s: Saving data into db...", datetime.now())
-    for video in collected_videos:
+    for video in reversed(collected_videos):
         channel, _ = models.YouTubeChannel.objects.get_or_create(
             channel_link=video["channel"].pop("channel_link"), defaults=video["channel"]
         )
@@ -104,6 +104,7 @@ def _save_data(collected_videos, search_query):
                 **video["video"],
                 youtube_query=search_query,
                 youtube_channel=channel,
+                created_at=datetime.now(),
             )
         )
 


### PR DESCRIPTION
<!--

Please use the content below as a template for your pull request.
Feel free to remove sections which do not make sense.

-->

## Scope

<!-- Brief description of WHAT you’re doing and WHY. -->

Ordering of videos was incorrect

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

I reverse the array so the oldest videos come first, add datetimes and save them so the latest videos have the newest times.

## How to Test

<!--

A straightforward scenario of how to test your changes could help colleagues that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->
Compare and contrast against youtube with the ordering of a query on our backend